### PR TITLE
Fix sometime cookie out of order comparison failed

### DIFF
--- a/LaravelCsrfToken.js
+++ b/LaravelCsrfToken.js
@@ -5,10 +5,14 @@ var CsrfToken = function() {
             cookies = (request.getHeaderByName('Cookie') || '').split(';'),
             token = null;
         
+        //fix some time order or the cookie change result in blank space
+        //apply trim will fix the issue
         for (var index in cookies) {
-            if (cookies[index].indexOf('XSRF-TOKEN') == 0) {
-                token = cookies[index].split('=')[1]
-            }
+        	var cookieName = cookies[index].split('=')[0].trim();
+
+        	if(cookieName == 'XSRF-TOKEN'){
+        		console.log( token =cookies[index].split('=')[1].trim());	
+        	}
         }
         
         return decodeURIComponent(token);


### PR DESCRIPTION
example sometime laravel response cookie like this

```cookie
remember_web_59ba36addc2b2f9401580f014c7f58ea4e30989d=eyJpdiI6IjhVeG83WXNIU1hOUGU4TXJzYkJycVE9PSIsInZhbHVlIjoidk5WRThVY1ZaVU1aalpNTGFUUDc4K1ZQdVRua1FCYkE5QjZOMHNiMG0wMTI5WkQzRVk1blFiRHNwaWlQV1hQTnhNVEhnbExuUCtxVjN6L2Y3YllWV1J3bUQ0SS9FMjMra3UxTlordFpTSVpsaWZERmdtSGIrQ1VKTmpxM1RZK0NRVVE2OG95aFpnS0tZT3V2cFBSV3h0YjBoeG5UNGxSWFJaa0RIeCtoWWE4PSIsIm1hYyI6ImE1Mjg4NDdhZjNjMzY1MjQ0NGJhNzMwYzBjZWE0NjczNTQ0OTU4OWRiMmMyOTcyYzIyMjJlZmE2ZGJjOGFlYWYifQ%3D%3D; XSRF-TOKEN=eyJpdiI6IjZ0am9oUjM1QzRPNDJWUXowSW4xZmc9PSIsInZhbHVlIjoiemEzU2JvQ01aMnFlb25zZ3RLNGdiSzFtdDNldmMxTDFGUmptYy9FK2I2bkIzdVBhUTFKb3paQ3AzaE9kaXQ3WiIsIm1hYyI6ImRlNjc4YjdlYTUyNzcwNzVlMjQ2YzMyY2JlNDM3OTZmYzUxZDBhOWJhZmQ2OWI1ZjNiMDRhYWU5MzE5Y2IzYTIifQ%3D%3D; sureplify_session=eyJpdiI6Ilp6UTlzTTNNWCtBOW5TN0llZ0FnRnc9PSIsInZhbHVlIjoiQVFDTVVIYVZibDFDNFJ1cW9VVGhsSDlJSEY2bUhyQ1pFWmx3Tm9KcFNGVnpzakkvYTJhSUhmNm1oaWJ6T3p2RiIsIm1hYyI6IjcxNDljNTVkMTgxMGM0YTVlMDdiNTYzNzlhZDJjNDlmY2EwZmM1YTMwMGZmMmZjZjAxMTNiYmMzNjU0ODZmNjUifQ%3D%3D
```

the original algorithm will break. result is null value on token.

this should fix it 